### PR TITLE
Move rules from onkcop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Add this line to your application's Gemfile:
 ```ruby
 gem "rubocop", require: false
 gem "rubocop-tsumug", require: false
-# Install the fork
-gem "onkcop", require: false, github: "sue445/onkcop", branch: "develop"
 ```
 
 And then execute:
@@ -35,10 +33,6 @@ sider.yml:
 linter:
   rubocop:
     gems:
-      - name: "onkcop"
-        git:
-          repo: "https://github.com/sue445/onkcop.git"
-          branch: "develop"
       - name: "rubocop-tsumug"
         git:
           repo: "https://github.com/tsumug/rubocop-tsumug.git"

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,51 +3,7 @@ require:
   - "rubocop-rails"
   - "rubocop-rspec"
 
-inherit_gem:
-  onkcop:
-    - "config/rubocop.yml"
-    - "config/rails.yml"
-    - "config/rspec.yml"
-
-AllCops:
-  NewCops: enable
-  Exclude:
-    - "bin/*"
-    - "log/**/*"
-    - "public/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-
-Naming/FileName:
-  Exclude:
-    - "db/Schemafile.rb"
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
-
-Metrics/AbcSize:
-  Max: 30
-
-Metrics/ClassLength:
-  Max: 300
-
-Metrics/MethodLength:
-  Max: 30
-
-Rails/DynamicFindBy:
-  Enabled: false
-
-Rails/EnvironmentVariableAccess:
-  AllowReads: true
-
-Rails/SaveBang:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Max: 20
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
+inherit_from:
+  - "rubocop.yml"
+  - "rails.yml"
+  - "rspec.yml"

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,0 +1,14 @@
+Rails/DynamicFindBy:
+  Enabled: false
+
+Rails/EnvironmentVariableAccess:
+  AllowReads: true
+
+Rails/FilePath:
+  Enabled: false
+
+Rails/Present:
+  Enabled: false
+
+Rails/SaveBang:
+  Enabled: false

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,0 +1,26 @@
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/DescribedClass:
+  EnforcedStyle: explicit
+
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 20
+
+RSpec/ExpectChange:
+  EnforcedStyle: block
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,0 +1,148 @@
+# Based on https://github.com/onk/onkcop
+
+AllCops:
+  NewCops: enable
+  Exclude:
+    - "bin/*"
+    - "log/**/*"
+    - "public/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+
+Layout/ClassStructure:
+  Enabled: true
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/IndentationConsistency:
+  EnforcedStyle: indented_internal_methods
+
+Layout/LineLength:
+  Max: 160
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
+Layout/SpaceInsideBlockBraces:
+  SpaceBeforeBlockParameters: false
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/BlockLength:
+  Exclude:
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
+    - "Gemfile"
+    - "Guardfile"
+    - "config/environments/*.rb"
+    - "config/routes.rb"
+    - "config/routes/**/*.rb"
+    - "*.gemspec"
+
+Metrics/ClassLength:
+  Max: 300
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+
+Metrics/MethodLength:
+  Max: 100
+
+Metrics/PerceivedComplexity:
+  Max: 30
+
+Naming/FileName:
+  Exclude:
+    - "db/Schemafile.rb"
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/BlockDelimiters:
+  AutoCorrect: false
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/GuardClause:
+  MinBodyLength: 5
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/PerlBackrefs:
+  AutoCorrect: false
+
+Style/PreferredHashMethods:
+  EnforcedStyle: verbose
+
+Style/RedundantReturn:
+  AllowMultipleReturnValues: true
+
+Style/RedundantSelf:
+  Enabled: false
+
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/WordArray:
+  Enabled: false

--- a/rubocop-tsumug.gemspec
+++ b/rubocop-tsumug.gemspec
@@ -30,7 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-performance'
   spec.add_runtime_dependency 'rubocop-rails'
   spec.add_runtime_dependency 'rubocop-rspec'
-
-  # GitHub のリポジトリを指定することはできないため、各プロジェクトでインストールする
-  # spec.add_runtime_dependency 'onkcop'
 end


### PR DESCRIPTION
- RuboCop のルールに onkcop を使っていたがメンテナンスが止まった
- RuboCop 標準のルールへの移行を考えたが困難だったので、onkcop からルールを移行したり、設定を変更した
  - Metrics 系ルールのしきい値を大幅に緩くした
- onkcop に感謝 🙏 